### PR TITLE
Update rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 %% -*- mode: erlang -*-
 %% vi: set ft=erlang :
-
+{erl_opts, []}.
 {eunit_opts, [verbose]}.


### PR DESCRIPTION
Hi Krzysztof

the empty list erlang options prevents rebar from crashing on compilation. Could you add it to rebar.config.

The below happens, if eenum does NOT have : {erl_opts, []}.

rpmbp:of_protocol ruanpienaar$ make
==> of_protocol (get-deps)
Pulling eenum from {git,"git://github.com/rpt/eenum.git",{branch,"master"}}
Cloning into 'eenum'...
Pulling meck from {git,"https://github.com/eproxus/meck.git",{tag,"0.8.2"}}
Cloning into 'meck'...
==> eenum (get-deps)
==> meck (get-deps)
==> eenum (compile)
/Users/ruanpienaar/code/of_protocol/deps/eenum/src/eenum.erl:none: undefined parse transform 'eenum'
ERROR: compile failed while processing /Users/ruanpienaar/code/of_protocol/deps/eenum: rebar_abort
make: **\* [compile] Error 1
