### PR TITLE
Fix rebar configuration for global parse_transform

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,6 @@
 %% -*- mode: erlang -*-
 %% vi: set ft=erlang :
 
+{erl_opts, []}.
+
 {eunit_opts, [verbose]}.


### PR DESCRIPTION
This is a fix to the issue reported in issue #3. Since I didn't hear anything else, I am assuming that this is one possible solution.
